### PR TITLE
Add Stretchdle to Non-word guesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Other languages
 Non-word guesses
 ----------------
 
+-   Aspect ratio of a stretched photo: [Stretchdle](https://seekdle.com/stretchdle/)
 -   Chess openings: [Chessle](https://jackli.gg/chessle/)
 -   Flags (1) with similar flags/colors:
     [Flaggle](https://ducc.pythonanywhere.com/flaggle/)


### PR DESCRIPTION
Adds Stretchdle under Non-word guesses: a daily game I made where a photo loads squished or stretched and you drag it back to its true proportions by eye, scored on accuracy. Free, daily, no login. Placed alphabetically by label. https://seekdle.com/stretchdle/